### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ imediff (2.2-2) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
   * Set upstream metadata fields: Bug-Database, Bug-Submit.
+  * Update standards version to 4.5.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 18:09:51 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+imediff (2.2-2) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 18:09:51 +0000
+
 imediff (2.2-1) unstable; urgency=medium
 
   * Refactor code and refine "g" key command.
@@ -23,7 +29,7 @@ imediff (2.0-1) unstable; urgency=medium
 
 imediff2 (1.1.2.1-2) unstable; urgency=medium
 
-  * Ship git-ime and git-ime.1. 
+  * Ship git-ime and git-ime.1.
 
  -- Osamu Aoki <osamu@debian.org>  Sun, 21 Oct 2018 02:45:03 +0900
 
@@ -48,7 +54,7 @@ imediff2 (1.1.2-3) unstable; urgency=medium
 
 imediff2 (1.1.2-2) unstable; urgency=medium
 
-  * debian/rules: 
+  * debian/rules:
     + Changed build architecture line to fix RC bug FTBFS binary build with no
       binary artifacts found. Closes: #831966.
     + Changed call to dh_clean -k to dh_prep.
@@ -174,4 +180,3 @@ imediff2 (1.0-1) unstable; urgency=low
   * Initial Release.
 
  -- Jarno Elonen <elonen@iki.fi>  Sun, 27 Apr 2003 02:11:31 +0300
-

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 imediff (2.2-2) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 18:09:51 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper-compat (= 12),
                python3-distutils-extra,
                python3-setuptools,
                xsltproc
-Standards-Version: 4.3.0
+Standards-Version: 4.5.0
 VCS-Git: https://github.com/osamuaoki/imediff.git -b master
 Vcs-Browser: https://github.com/osamuaoki/imediff
 Homepage: https://github.com/osamuaoki/imediff

--- a/debian/rules
+++ b/debian/rules
@@ -4,4 +4,3 @@
 
 %:
 	dh $@ --with python3 --buildsystem=pybuild
-

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,2 @@
+Bug-Database: https://github.com/osamuaoki/imediff/issues
+Bug-Submit: https://github.com/osamuaoki/imediff/issues/new


### PR DESCRIPTION
Fix some issues reported by lintian
* Trim trailing whitespace. ([file-contains-trailing-whitespace](https://lintian.debian.org/tags/file-contains-trailing-whitespace.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html))
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/imediff/5e448223-730b-4f67-a8e6-929bcc399a8f.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/5e448223-730b-4f67-a8e6-929bcc399a8f/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/5e448223-730b-4f67-a8e6-929bcc399a8f/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/5e448223-730b-4f67-a8e6-929bcc399a8f/diffoscope)).
